### PR TITLE
Support TeXLive 2018

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,11 @@ FROM frolvlad/alpine-glibc
 
 MAINTAINER 3846masa
 
-ENV PATH /usr/local/texlive/2017/bin/x86_64-linux:$PATH
+ENV PATH /usr/local/texlive/2018/bin/x86_64-linuxmusl:$PATH
 
 RUN apk --no-cache add perl wget xz tar fontconfig-dev && \
     mkdir /tmp/install-tl-unx && \
-    wget -qO- ftp://tug.org/texlive/historic/2017/install-tl-unx.tar.gz | \
+    wget -qO - ftp://tug.org/historic/systems/texlive/2018/install-tl-unx.tar.gz | \
     tar -xz -C /tmp/install-tl-unx --strip-components=1 && \
     printf "%s\n" \
       "selected_scheme scheme-basic" \


### PR DESCRIPTION
## Overview
- Fix binary PATH for TeXLive 2018.
- Change TeXLive 2018 installation file URL.
- Fix wget options.