### PR TITLE
add ghostscript to use eps image file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk --no-cache add perl wget xz tar fontconfig-dev freetype-dev && \
     rm -fr /tmp/install-tl-unx && \
     apk --no-cache del xz tar
 
-RUN apk --no-cache add bash
+RUN apk --no-cache add bash ghostscript
 
 RUN mkdir /workdir
 


### PR DESCRIPTION
When eps image file (.eps) is inputed in tex file, it doesn't work. The error which caused by the absence of Ghostscript. Then, I added a new line to install Ghostscript.