### PR TITLE
Remove unnecessary mkdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN apk --no-cache add perl wget xz tar fontconfig-dev freetype-dev && \
 
 RUN apk --no-cache add bash
 
-RUN mkdir /workdir
-
 WORKDIR /workdir
 
 VOLUME ["/workdir"]


### PR DESCRIPTION
Hi.
WORKDIR make directory if it does not exist, we can remove mkdir. [1]
And this reduces the number of layers, which is 96bytes less. [2]

```
  $ docker image build -t conao3/texlive .
  ...

  Successfully tagged conao3/texlive:latest

  $ docker container run -it conao3/texlive
  bash-4.4# cd /
  bash-4.4# ls -1
  bin
  ...

  var
  workdir
```

cf:
  [1]: http://docs.docker.jp/engine/reference/builder.html#workdir
  [2]: https://microbadger.com/images/paperist/alpine-texlive-ja