### PR TITLE
Clearify install dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,9 @@ RUN apk add --no-cache perl fontconfig-dev freetype-dev && \
     /tmp/install-tl-unx/install-tl \
       --profile=/tmp/install-tl-unx/texlive.profile && \
     tlmgr install \
-      collection-latexrecommended collection-latexextra \
-      collection-fontsrecommended collection-langjapanese \
+      collection-latexextra \
+      collection-fontsrecommended \
+      collection-langjapanese \
       latexmk && \
     rm -fr /tmp/install-tl-unx && \
     apk del .fetch-deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,16 +14,15 @@ RUN apk add --no-cache perl fontconfig-dev freetype-dev && \
     tar -xz -C /tmp/install-tl-unx --strip-components=1 && \
     printf "%s\n" \
       "selected_scheme scheme-basic" \
-      "option_doc 0" \
-      "option_src 0" \
+      "tlpdbopt_install_docfiles 0" \
+      "tlpdbopt_install_srcfiles 0" \
       > /tmp/install-tl-unx/texlive.profile && \
     /tmp/install-tl-unx/install-tl \
       --profile=/tmp/install-tl-unx/texlive.profile && \
     tlmgr install \
-      collection-basic collection-latex \
       collection-latexrecommended collection-latexextra \
       collection-fontsrecommended collection-langjapanese \
-      latexmk dvipdfmx && \
+      latexmk && \
     rm -fr /tmp/install-tl-unx && \
     apk del .fetch-deps
 


### PR DESCRIPTION
Dear Paperist

I have made minor modifications on the Dockerfile.  Could you please check?

1. According to the [install-tl manual](http://www.tug.org/texlive/doc/install-tl.html#PROFILES), it seems that `tlpdbopt_install_docfiles`(resp. `tlpdbopt_install_scrfiles`) is used instead of `option_doc`(resp. `option_src`).

2. The scheme `scheme-basic` contains `collection-basic` and `collection-latex`(we can check that by `tlmgr info --list scheme-basic` in a terminal).

3. `dvipdfmx` is contained in `collection-basic`(similarly, we can check that by the `tlmgr` command).

The changes about 2) and 3) may not affect; I am very sorry for not being familiar with LaTeX ecosystems.
If this Pull Request is silly, please close.

*EDIT*
Sorry, I now realized that `collection-latexrecommended` seems to be contained in `collection-latexextra`, but not modify it.

Regards,