### PR TITLE
Install curl for installing other CTAN packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ FROM frolvlad/alpine-glibc:latest
 
 ENV PATH /usr/local/texlive/2019/bin/x86_64-linux:$PATH
 
-RUN apk add --no-cache perl fontconfig-dev freetype-dev && \
+RUN apk add --no-cache curl perl fontconfig-dev freetype-dev && \
     apk add --no-cache --virtual .fetch-deps wget xz tar && \
     mkdir /tmp/install-tl-unx && \
-    wget -qO - ftp://tug.org/historic/systems/texlive/2019/install-tl-unx.tar.gz | \
+    curl ftp://tug.org/historic/systems/texlive/2019/install-tl-unx.tar.gz | \
     tar -xz -C /tmp/install-tl-unx --strip-components=1 && \
     printf "%s\n" \
       "selected_scheme scheme-basic" \


### PR DESCRIPTION
Dear Paperist

Thank you for a convinient docker images.

I could not install other packages from CTAN,
but solved by installation of curl.
(refer to https://hub.docker.com/r/shimastripe/texlive-ja/dockerfile)

I have made minor modifications on the Dockerfile.
Please please check Dockerfile.

Regards